### PR TITLE
Update document-register-element.js

### DIFF
--- a/src/document-register-element.js
+++ b/src/document-register-element.js
@@ -1,5 +1,6 @@
 
 var
+  REGISTER_ELEMENT = 'registerElement'
   // IE < 11 only + old WebKit for attributes + feature detection
   EXPANDO_UID = '__' + REGISTER_ELEMENT + (Math.random() * 10e4 >> 0),
 


### PR DESCRIPTION
Glad to see something other than me using shortcuts like vhV instead of 'selfexplanatory' names like
thisIsTheVariableHoldingTheValueOfObjectsPropertyThatIDefineLater.

Without defining REGISTER_ELEMENT nothing works, but now ... superb!

Many thanks for sharing this fine piece of code.
