### PR TITLE
Adding uglify-js version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test": "node test/.test.js"
   },
   "devDependencies": {
-    "wru": ">= 0.0.0"
+    "wru": ">= 0.0.0",
+    "uglify-js": "1.x"
   }
 }


### PR DESCRIPTION
Small fix of the required node dependencies. In order to have a stable uglify-js mangling, resulting in the same build artefacts, the major version has to be 1.x