### PR TITLE
IE10 fix for bubbling event for property change

### DIFF
--- a/src/document-register-element.js
+++ b/src/document-register-element.js
@@ -416,6 +416,9 @@ function onDOMAttrModified(e) {
     prevValue = e.prevValue,
     newValue = e.newValue
   ;
+  if (e.target !== node) {
+    return;
+  }
   if (notFromInnerHTMLHelper &&
       node.attributeChangedCallback &&
       e.attrName !== 'style') {

--- a/src/document-register-element.js
+++ b/src/document-register-element.js
@@ -417,7 +417,7 @@ function onDOMAttrModified(e) {
     newValue = e.newValue
   ;
   if (e.target !== node) {
-    return;
+      return;
   }
   if (notFromInnerHTMLHelper &&
       node.attributeChangedCallback &&


### PR DESCRIPTION
### Issue ###
We have nested components, and each one has attached the event "DOMAttrModified". So, if you try to change a property, this bubbles and tries to change the property from an upper component.
This only happens in IE10.

### Solution ###
The solution we found is to stop the change if the target element is not the same as the current one.

### Reason ###
I don't know if there is a valid scenario when you want to bubble changing the value if you have nested elements that shares properties, as this will get updated with the same value.