### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ class MyDom extends HTMLElement {
     alert(name + ':' + newValue);
   }
 }
-
+customElements.define('my-dom', MyDom);
 var md = new MyDom();
 md.setAttribute('test', 'nope');
 md.setAttribute('country', 'UK'); // country: UK


### PR DESCRIPTION
The example only works if you register the class with customElements.

Alternatively, this may need fixing:

info = constructors[nodeNames.get(self.constructor)];
isNative = usableCustomElements && info.create.length === 1;

info is undefined in this case, cause the class is not registered. I'll have another patch for that.