### PR TITLE
Add an event similar to webcomponentsjs

### DIFF
--- a/template/var.after
+++ b/template/var.after
@@ -1,2 +1,3 @@
 
+var evt=document.createEvent("HTMLEvents");evt.initEvent("WebComponentsReady", true, true);window.dispatchEvent(evt);
 }(window));


### PR DESCRIPTION
### Dispatch an event

This is tiny addition to the build script (affects only the plain js script), that will dispatch an event similar to webcomponentsjs polypill.

This might be handy if you want to have the logic that includes the polyfill in a file (conforming the strict CSP standard) but you also need to make sure the `customElements.define()` doesn't run prematurely.

This is my custom loader script:
```js
(function(){
'use strict';

// Check if ES6 is ok
if(!Object.Reflect) {
	var newScr=document.createElement('script');newScr.src='//cdnjs.cloudflare.com/ajax/libs/es6-shim/0.35.3/es6-shim.js';document.head.appendChild(newScr);
}
// Check if custom elements are natively supported
if (!window.customElements) {
	var name = 'ce-loader.js',
	script = document.querySelector('script[src*="' + name + '"]'),
	newScript = document.createElement('script'),
	url = script.src.replace(name,'document-register-element.js');
	newScript.src=url;document.head.appendChild(newScript);
}else{
	document.addEventListener('DOMContentLoaded', function() {
		window.dispatchEvent(new CustomEvent('WebComponentsReady'));
	});
}
})();
```