### PR TITLE
Added browser field in package.json for bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "url": "git://github.com/WebReflection/document-register-element.git"
   },
   "main": "./build/document-register-element.node.js",
+  "browser": "./build/document-register-element.js",
   "scripts": {
     "test": "phantomjs testrunner.js",
     "web": "tiny-cdn run -p=1337"


### PR DESCRIPTION
Just for bundlers like rollupjs where we can decide to build for browser.