### PR TITLE
Adding "|| exit 0" to prevent downstream failure in npm processes

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "test": "phantomjs testrunner.js",
     "web": "tiny-cdn run -p=1337",
-    "postinstall": "lightercollective"
+    "postinstall": "lightercollective || exit 0"
   },
   "devDependencies": {
     "html-class": "^1.2.0",


### PR DESCRIPTION
Various environmental or project scenarios may lead to a failure when calling lightercollective from postinstall. This is not known to be a lightercollective failure, but instead of a failure to properly call the lightercollective library. One such known scenario on Windows being multiple path casings being passed to child_process.spawn when npm-lifecycle processes postinstall.

Discussion on lifecycle/postinstall Win32 issue here: https://github.com/npm/npm-lifecycle/issues/29

This PR is intended to address this discussion: https://github.com/WebReflection/document-register-element/pull/165