### PR TITLE
Don't process custom elements in templates

### DIFF
--- a/src/document-register-element.js
+++ b/src/document-register-element.js
@@ -816,7 +816,7 @@ function verifyAndSetupAndAction(node, action) {
     i = getTypeIndex(node),
     counterAction
   ;
-  if (-1 < i) {
+  if ((-1 < i) && !isInTemplate(node)) {
     patchIfNotAlready(node, protos[i]);
     i = 0;
     if (action === ATTACHED && !node[ATTACHED]) {
@@ -840,6 +840,35 @@ function verifyAndSetupAndAction(node, action) {
   }
 }
 
+var isInTemplate = (
+  HTMLElementPrototype.matches ?
+		function(node) {return node.matches(          'template *') || isTemplateContent(node)} : (
+  HTMLElementPrototype.msMatchesSelector ?
+		function(node) {return node.msMatchesSelector('template *') || isTemplateContent(node)} :
+	function(node) {
+		return isTemplateContent(node) || (
+			function recurseIsInTemplate(element) {
+			 	 return element && (
+			 		 (element.nodeName === 'TEMPLATE') ||
+			 		 recurseIsInTemplate(element.parentElement)
+			 	 );
+ 		 	}
+		)(node);
+	}
+));
+
+function isTemplateContent(node) {
+	var templates = document.querySelectorAll('template');
+	var contents = [];
+	for(var i = 0; i < templates.length; i++) {
+		var content = templates[i].content;
+		if(content) contents.push(content);
+	}
+	var hostNode = (function host(element) {
+		return element.parentNode ? host(element.parentNode) : element;
+	})(node);
+	return contents.indexOf(hostNode) !== -1;
+}
 
 
 // V1 in da House!


### PR DESCRIPTION
@WebReflection Thanks for all the help!

With your a help and one more fix (see here) I was able to get everything running on IE. The thing I fixed has to do with templates. As per spec, templates should be ignored while rendering HTML. However,  document-regester-element, being oblivious to templates, instantiates everything in templates and calls the constructors of the elements in the templates.

This fixes that. However, I actually fixed it in the "esm" build and copied the fix into the source. I should build and test it, but the package.json has no build script - is it built with `make` (that does something but exits with a fail)?

Also I assume my code is not the most efficient one. I just wanted to get it rolling and hope you may have an idea how to hook it up more efficiently - if you care about that fix at all, that is.

So do you?

    Cheers
    Thorsten