### PR TITLE
PotentialCustomElementName

### DIFF
--- a/src/document-register-element.js
+++ b/src/document-register-element.js
@@ -35,7 +35,7 @@ var
   PREFIX_IS = '=',
 
   // valid and invalid node names
-  validName = /^[A-Z][A-Z0-9]*(?:[-|.|_][A-Z0-9]+)+$/,
+  validName = /^[A-Z](\.|-|_|[A-Z])*(?:-)(\.|-|_|[A-Z])*$/,
   invalidNames = [
     'ANNOTATION-XML',
     'COLOR-PROFILE',

--- a/src/document-register-element.js
+++ b/src/document-register-element.js
@@ -35,7 +35,7 @@ var
   PREFIX_IS = '=',
 
   // valid and invalid node names
-  validName = /^[A-Z](\.|-|_|[A-Z])*(?:-)(\.|-|_|[A-Z])*$/,
+  validName = /^[A-Z](\.|-|_|[A-Z0-9])*(?:-)(\.|-|_|[A-Z0-9])*$/,
   invalidNames = [
     'ANNOTATION-XML',
     'COLOR-PROFILE',

--- a/src/document-register-element.js
+++ b/src/document-register-element.js
@@ -35,7 +35,7 @@ var
   PREFIX_IS = '=',
 
   // valid and invalid node names
-  validName = /^[A-Z](\.|-|_|[A-Z0-9])*(?:-)(\.|-|_|[A-Z0-9])*$/,
+  validName = /^[A-Z][-._A-Z0-9]*-[-._A-Z0-9]*$/,
   invalidNames = [
     'ANNOTATION-XML',
     'COLOR-PROFILE',

--- a/src/document-register-element.js
+++ b/src/document-register-element.js
@@ -35,7 +35,7 @@ var
   PREFIX_IS = '=',
 
   // valid and invalid node names
-  validName = /^[A-Z][A-Z0-9]*(?:-[A-Z0-9]+)+$/,
+  validName = /^[A-Z][A-Z0-9]*(?:[-|.|_][A-Z0-9]+)+$/,
   invalidNames = [
     'ANNOTATION-XML',
     'COLOR-PROFILE',


### PR DESCRIPTION
bug: <xxx.a-b> as customElementName will throw error The type xxx.a-b  is invalid

explain: 
[customElementName](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name) as the advice I hope use the <xxx.a-b> as the customElementName, xxx as the namespace but I found that the validName test in the file(document-register-element.js) is not suitable at all.

hope your response Thanks