### PR TITLE
Fix registering elemenets with text nodes

### DIFF
--- a/src/document-register-element.js
+++ b/src/document-register-element.js
@@ -570,6 +570,11 @@ if (!V0) {
             )
               fragment.appendChild(document.importNode(childNodes[i], !!deep));
             return fragment;
+          case 3:
+            // Handle Text nodes
+            var fragment = document.createDocumentFragment();
+            fragment.textContent = node.wholeText;
+            return fragment;
           default:
             return cloneNode.call(node, !!deep);
         }


### PR DESCRIPTION
When working with `lit-html` and Jest with JSDom, I am running into errors when importing a custom element when there are text nodes. 

```
TypeError: Illegal invocation



      at Text.getAttribute (node_modules/jest-environment-jsdom-fourteen/node_modules/jsdom/lib/jsdom/living/generated/Element.js:41:13)
      at getTypeIndex (node_modules/document-register-element/build/document-register-element.node.js:788:27)
      at setupAll (node_modules/document-register-element/build/document-register-element.node.js:842:13)
      at Text.HTMLElementPrototype.cloneNode (node_modules/document-register-element/build/document-register-element.node.js:693:18)
      at Document.document.importNode (node_modules/document-register-element/build/document-register-element.node.js:688:32)
      at Document.document.importNode (node_modules/document-register-element/build/document-register-element.node.js:672:47)
      at node_modules/lit-html/directives/unsafe-html.js:52:29
      at NodePart.commit (node_modules/lit-html/lib/parts.js:236:7)
      at TemplateInstance.update (node_modules/lit-html/lib/template-instance.js:73:15)
      at NodePart.__commitTemplateResult (node_modules/lit-html/lib/parts.js:315:16)
```

This patch fixes it, but I am unsure exactly how to wrap a test for this.