### PR TITLE
removed lightercollective

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
   "unpkg": "./build/document-register-element.js",
   "scripts": {
     "test": "phantomjs testrunner.js",
-    "web": "tiny-cdn run -p=1337",
-    "postinstall": "node \"$(npm bin)/lightercollective\""
+    "web": "tiny-cdn run -p=1337"
   },
   "devDependencies": {
     "html-class": "^1.2.0",
@@ -42,13 +41,5 @@
     "tiny-cdn": "^0.7.0",
     "uglify-js": "^2.8.29",
     "wru": "^0.3.0"
-  },
-  "dependencies": {
-    "lightercollective": "^0.3.0"
-  },
-  "collective": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/document-register-element",
-    "logo": "logo.txt"
   }
 }


### PR DESCRIPTION
[this MR](https://github.com/WebReflection/document-register-element/pull/183) broke [too many envs](https://github.com/WebReflection/document-register-element/issues/185) so, since this module is deprecated, I've decided to remove the lightercollective entirely and later on deprecate this properly redirecting to [its best alternative](https://github.com/ungap/custom-elements#readme)